### PR TITLE
init.sh iptables changes

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -29,16 +29,22 @@ chmod 600 /dev/net/tun
 # Set up firewall to block all traffic except VPN, DNS and ICMP (ping)
 # Note: if you run the VPN on 443 or 80 TCP, HTTP or HTTPS traffic may
 #       be able to leak through the firewall if specifically directed to eth0
-iptables -A OUTPUT -o tun0 -m comment --comment "vpn" -j ACCEPT
-iptables -A OUTPUT -o eth0 -p icmp -m comment --comment "icmp" -j ACCEPT
-iptables -A OUTPUT -d 192.168.0.0/16 -o eth0 -m comment --comment "lan /16" -j ACCEPT
-iptables -A OUTPUT -d 172.16.0.0/12 -o eth0 -m comment --comment "lan /12" -j ACCEPT
-iptables -A OUTPUT -d 10.0.0.0/8 -o eth0 -m comment --comment "lan /8" -j ACCEPT
-iptables -A OUTPUT -o eth0 -p udp -m udp --dport $PORT -m comment --comment "openvpn" -j ACCEPT
-iptables -A OUTPUT -o eth0 -p tcp -m tcp --dport $PORT -m comment --comment "openvpn" -j ACCEPT
-iptables -A OUTPUT -o eth0 -p udp -m udp --dport 53 -m comment --comment "dns" -j ACCEPT
-iptables -A OUTPUT -o eth0 -p tcp -m tcp --dport 53 -m comment --comment "dns" -j ACCEPT
-iptables -A OUTPUT -o eth0 -j DROP
+iptables -A OUTPUT -o tun0 -j ACCEPT # Permit everything from tun0
+iptables -A OUTPUT -o eth0 -p icmp -j ACCEPT # Permit all ICMP from eth0
+iptables -A OUTPUT -d 192.168.0.0/16 -o eth0 -j ACCEPT # Permit all to LAN from eth0
+iptables -A OUTPUT -d 172.16.0.0/12 -o eth0 -j ACCEPT # Permit all to LAN from eth0
+iptables -A OUTPUT -d 10.0.0.0/8 -o eth0 -j ACCEPT # Permit all to LAN from eth0
+
+# Permit elected UDP port if UDP config file is elected, else permit elected TCP port
+if [[ $CRYPTOSTORM_CONFIG_FILE =~ "udp.ovpn" ]]; then
+    iptables -A OUTPUT -o eth0 -p udp -m udp --dport $PORT -j ACCEPT #permit VPN traffic out of eth0
+else
+    iptables -A OUTPUT -o eth0 -p tcp -m tcp --dport $PORT -j ACCEPT #permit VPN traffic out of eth0
+fi
+
+iptables -A OUTPUT -o eth0 -p udp -m udp --dport 53 -j ACCEPT # Permit UDP DNS from eth0 
+iptables -A OUTPUT -o eth0 -p tcp -m tcp --dport 53 -j ACCEPT # Permit TCP DNS from eth0 
+iptables -A OUTPUT -o eth0 -j DROP # Drop everything else
 
 # Start openvpn (requires NET_ADMIN)
 openvpn --client --auth-user-pass /config/credentials --config /ovpn-configs/$CRYPTOSTORM_CONFIG_FILE


### PR DESCRIPTION
Only permitted out the openVPN protocol required (udp or tcp), and stripped out the comment extension/field from iptables commands as that kernel module is not present on all linux systems (isn't present on Synology devices).